### PR TITLE
Add option to reuse identical generated structs and deduplicate implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,13 @@
                         All public
                     </label>
                 </li>
+                <li>
+                    <label data-placement="bottom" data-tooltip="Reuse the first generated struct when another object has identical fields"
+                        for="ck_reuse_identical_structs">
+                        <input type="checkbox" id="ck_reuse_identical_structs" onclick="loadFlags()" name="ck_reuse_identical_structs" checked>
+                        reuse identical structures
+                    </label>
+                </li>
             </ul>
             <ul></ul>
             <ul></ul>

--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ try {
 /** @type {{nameType: string, type: string, types: []Object}[]} */
 let afterImplementationTypes = [];
 
+/** @type {Map<string, string>} */
+let implementationTypeBySignature = new Map();
+
 var editorVlang = ace.edit("editorVlang");
 var editorJson = ace.edit("editorJson");
 
@@ -55,11 +58,13 @@ var flagAllPublic = true;
 var flagOmitEmpty = true;
 var flagReserverdWordsWithAt = false;
 var flagStructAnon = false;
+var flagReuseIdenticalStructs = true;
 function loadFlags() {
     flagAllPublic = document.getElementById('ck_all_pubblic').checked;
     flagOmitEmpty = document.getElementById('ck_omitempty').checked;
     flagReserverdWordsWithAt = document.getElementById('ck_reserved_word').checked;
     flagStructAnon = document.getElementById('ck_struct_anon').checked;
+    flagReuseIdenticalStructs = document.getElementById('ck_reuse_identical_structs').checked;
     runCode();
 }
 
@@ -74,12 +79,40 @@ function pushAfterImplementationType(type) {
         afterImplementationTypes.push(type);
 }
 
+function getImplementationTypeSignature(fields) {
+    return fields
+        .trim()
+        .split('\n')
+        .map(it => it.trim())
+        .filter(it => it !== '')
+        .sort()
+        .join('\n');
+}
+
+function resolveImplementationType(nameType, fields, type = '') {
+    const signature = getImplementationTypeSignature(fields);
+    const existentNameType = implementationTypeBySignature.get(signature);
+
+    if (existentNameType !== undefined)
+        return existentNameType;
+
+    implementationTypeBySignature.set(signature, nameType);
+    pushAfterImplementationType({
+        nameType: nameType,
+        types: [fields],
+        type: type
+    });
+
+    return nameType;
+}
+
 
 /**
  * @description Add a new type to the list of types to be implemented and convert the json to struct
  */
 function jsonToStruct(js, type_obj = undefined) {
     afterImplementationTypes = [];
+    implementationTypeBySignature = new Map();
     let code = constructStrucFromJson(js, type_obj).code;
 
     if (code === null)
@@ -249,16 +282,22 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
                 return 'Undefined';
         })();
 
+        const nameType = resolverNameType(name);
+        let resolvedNameType = nameType;
+
         if (!flagStructAnon) {
-            pushAfterImplementationType({
-                nameType: resolverNameType(name),
-                types: [typeRoot],
-                type: typesArray.length > 1 ? 'sumType' : ''
-            });
+            if (flagReuseIdenticalStructs)
+                resolvedNameType = resolveImplementationType(nameType, typeRoot, typesArray.length > 1 ? 'sumType' : '');
+            else
+                pushAfterImplementationType({
+                    nameType: nameType,
+                    types: [typeRoot],
+                    type: typesArray.length > 1 ? 'sumType' : ''
+                });
         }
 
         typeRoot = {
-            code: !flagStructAnon ? name : `struct {${canIsPublicForFields(typeRoot.trim(), `\t`)}\n${typeRoot.replaceAll('\t', '\t\t')}\t}`,
+            code: !flagStructAnon ? resolvedNameType : `struct {${canIsPublicForFields(typeRoot.trim(), `\t`)}\n${typeRoot.replaceAll('\t', '\t\t')}\t}`,
         };
     }
     else if (constructStructWithSumType(typesArray)) {


### PR DESCRIPTION
### Motivation
- Avoid generating duplicate struct definitions when multiple JSON objects have identical fields by reusing the first generated struct implementation. 
- Expose this behavior as a user-configurable checkbox to allow toggling deduplication in the UI.

### Description
- Added a new checkbox option in `index.html` labeled "reuse identical structures" to control reusing identical struct implementations. 
- Introduced `implementationTypeBySignature` Map and helper functions `getImplementationTypeSignature` and `resolveImplementationType` in `index.js` to detect and reuse identical type implementations based on a normalized fields signature. 
- Added a new flag `flagReuseIdenticalStructs` and wired it into `loadFlags()` to toggle the feature, and reset the map at the start of `jsonToStruct()`. 
- Updated struct generation logic to use a resolved (possibly reused) type name (`resolvedNameType`) when deduplication is enabled, otherwise preserving the previous behavior of always emitting a new type.

### Testing
- No automated tests were executed for this change.