### PR TITLE
Persist JSON editor contents to localStorage

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ let afterImplementationTypes = [];
 /** @type {Map<string, string>} */
 let implementationTypeBySignature = new Map();
 
+const defaultJson = '{\n\t"example_construct_struct": "",\n\t"person": {\n\t\t"name": "André",\n\t\t"age": 26\n\t}\n}';
+const lastJsonLocalStorageKey = 'json2v:last-json';
+
 var editorVlang = ace.edit("editorVlang");
 var editorJson = ace.edit("editorJson");
 
@@ -35,15 +38,31 @@ function main() {
     editorJson.session.setMode("ace/mode/json");
     editorJson.getSession().on('change', runCode);
 
-    editorJson.setValue('{\n\t"example_construct_struct": "",\n\t"person": {\n\t\t"name": "André",\n\t\t"age": 26\n\t}\n}');
+    editorJson.setValue(getLastJson());
     loadFlags();
 }
 
+function getLastJson() {
+    try {
+        const lastJson = localStorage.getItem(lastJsonLocalStorageKey);
+        return lastJson !== null ? lastJson : defaultJson;
+    } catch {
+        return defaultJson;
+    }
+}
 
+function saveLastJson(json) {
+    try {
+        localStorage.setItem(lastJsonLocalStorageKey, json);
+    } catch { }
+}
 
 function runCode() {
     try {
-        const code = jsonToStruct(editorJson.getValue())
+        const json = editorJson.getValue();
+        saveLastJson(json);
+
+        const code = jsonToStruct(json)
 
         if (code === null)
             return;


### PR DESCRIPTION
### Motivation
- Preserve the JSON typed into the editor across browser sessions so users don't lose work when refreshing or closing the page. 
- Fall back to the existing example JSON when no saved content exists or `localStorage` access fails.

### Description
- Added constants `defaultJson` and `lastJsonLocalStorageKey` in `index.js` to hold the example payload and the storage key. 
- Implemented `getLastJson()` and `saveLastJson(json)` to read/write the editor content from/to `localStorage`. 
- Updated initialization to call `editorJson.setValue(getLastJson())` and updated `runCode()` to call `saveLastJson(json)` before converting the JSON to V types; all changes are in `index.js`.

### Testing
- Ran `node --check index.js` to validate syntax, which succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/format issues, which succeeded.