### PR TITLE
Persist JSON editor, deduplicate identical structs, and update GitHub Pages actions

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -92,6 +92,13 @@
                         All public
                     </label>
                 </li>
+                <li>
+                    <label data-placement="bottom" data-tooltip="Reuse the first generated struct when another object has identical fields"
+                        for="ck_reuse_identical_structs">
+                        <input type="checkbox" id="ck_reuse_identical_structs" onclick="loadFlags()" name="ck_reuse_identical_structs" checked>
+                        reuse identical structures
+                    </label>
+                </li>
             </ul>
             <ul></ul>
             <ul></ul>

--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ try {
 /** @type {{nameType: string, type: string, types: []Object}[]} */
 let afterImplementationTypes = [];
 
+/** @type {Map<string, string>} */
+let implementationTypeBySignature = new Map();
+
+const defaultJson = '{\n\t"example_construct_struct": "",\n\t"person": {\n\t\t"name": "André",\n\t\t"age": 26\n\t}\n}';
+const lastJsonLocalStorageKey = 'json2v:last-json';
+
 var editorVlang = ace.edit("editorVlang");
 var editorJson = ace.edit("editorJson");
 
@@ -32,15 +38,31 @@ function main() {
     editorJson.session.setMode("ace/mode/json");
     editorJson.getSession().on('change', runCode);
 
-    editorJson.setValue('{\n\t"example_construct_struct": "",\n\t"person": {\n\t\t"name": "André",\n\t\t"age": 26\n\t}\n}');
+    editorJson.setValue(getLastJson());
     loadFlags();
 }
 
 
+function getLastJson() {
+    try {
+        const lastJson = localStorage.getItem(lastJsonLocalStorageKey);
+        return lastJson !== null ? lastJson : defaultJson;
+    } catch {
+        return defaultJson;
+    }
+}
+
+function saveLastJson(json) {
+    try {
+        localStorage.setItem(lastJsonLocalStorageKey, json);
+    } catch { }
+}
 
 function runCode() {
     try {
-        const code = jsonToStruct(editorJson.getValue())
+        const json = editorJson.getValue();
+        saveLastJson(json);
+        const code = jsonToStruct(json)
 
         if (code === null)
             return;
@@ -55,11 +77,13 @@ var flagAllPublic = true;
 var flagOmitEmpty = true;
 var flagReserverdWordsWithAt = false;
 var flagStructAnon = false;
+var flagReuseIdenticalStructs = true;
 function loadFlags() {
     flagAllPublic = document.getElementById('ck_all_pubblic').checked;
     flagOmitEmpty = document.getElementById('ck_omitempty').checked;
     flagReserverdWordsWithAt = document.getElementById('ck_reserved_word').checked;
     flagStructAnon = document.getElementById('ck_struct_anon').checked;
+    flagReuseIdenticalStructs = document.getElementById('ck_reuse_identical_structs').checked;
     runCode();
 }
 
@@ -74,12 +98,40 @@ function pushAfterImplementationType(type) {
         afterImplementationTypes.push(type);
 }
 
+function getImplementationTypeSignature(fields) {
+    return fields
+        .trim()
+        .split('\n')
+        .map(it => it.trim())
+        .filter(it => it !== '')
+        .sort()
+        .join('\n');
+}
+
+function resolveImplementationType(nameType, fields, type = '') {
+    const signature = getImplementationTypeSignature(fields);
+    const existentNameType = implementationTypeBySignature.get(signature);
+
+    if (existentNameType !== undefined)
+        return existentNameType;
+
+    implementationTypeBySignature.set(signature, nameType);
+    pushAfterImplementationType({
+        nameType: nameType,
+        types: [fields],
+        type: type
+    });
+
+    return nameType;
+}
+
 
 /**
  * @description Add a new type to the list of types to be implemented and convert the json to struct
  */
 function jsonToStruct(js, type_obj = undefined) {
     afterImplementationTypes = [];
+    implementationTypeBySignature = new Map();
     let code = constructStrucFromJson(js, type_obj).code;
 
     if (code === null)
@@ -249,16 +301,22 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
                 return 'Undefined';
         })();
 
+        const nameType = resolverNameType(name);
+        let resolvedNameType = nameType;
+
         if (!flagStructAnon) {
-            pushAfterImplementationType({
-                nameType: resolverNameType(name),
-                types: [typeRoot],
-                type: typesArray.length > 1 ? 'sumType' : ''
-            });
+            if (flagReuseIdenticalStructs)
+                resolvedNameType = resolveImplementationType(nameType, typeRoot, typesArray.length > 1 ? 'sumType' : '');
+            else
+                pushAfterImplementationType({
+                    nameType: nameType,
+                    types: [typeRoot],
+                    type: typesArray.length > 1 ? 'sumType' : ''
+                });
         }
 
         typeRoot = {
-            code: !flagStructAnon ? name : `struct {${canIsPublicForFields(typeRoot.trim(), `\t`)}\n${typeRoot.replaceAll('\t', '\t\t')}\t}`,
+            code: !flagStructAnon ? resolvedNameType : `struct {${canIsPublicForFields(typeRoot.trim(), `\t`)}\n${typeRoot.replaceAll('\t', '\t\t')}\t}`,
         };
     }
     else if (constructStructWithSumType(typesArray)) {

--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ function main() {
 
 function getLastJson() {
     try {
-        const lastJson = localStorage.getItem(lastJsonLocalStorageKey);
-        return lastJson !== null ? lastJson : defaultJson;
+        return localStorage.getItem(lastJsonLocalStorageKey) ?? defaultJson;
     } catch {
         return defaultJson;
     }


### PR DESCRIPTION
### Motivation
- Update the GitHub Pages deployment workflow to use newer action versions for more reliable deployments.
- Persist the JSON editor content across browser sessions so users don't lose their work between visits.
- Prevent duplicate struct implementations by reusing the first generated struct when another object has identical fields and make this behavior user-configurable.

### Description
- Bumped GitHub Actions in `.github/workflows/page.yml` to `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4`.
- Added a new checkbox in `index.html` with id `ck_reuse_identical_structs` to enable/disable reuse of identical structures and included a tooltip describing the behavior.
- In `index.js` introduced `implementationTypeBySignature` `Map`, `getImplementationTypeSignature`, and `resolveImplementationType` to compute a canonical signature for field sets and deduplicate types; added `flagReuseIdenticalStructs` and wired it into `loadFlags`.
- Implemented `localStorage` persistence with `getLastJson`, `saveLastJson`, and `lastJsonLocalStorageKey` (`json2v:last-json`), set the editor initial value to `getLastJson()`, and save on every change.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b067858ec832c9621ce6435dccffe)