### PR TITLE
Alphabetize generated struct fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,20 @@ function getImplementationTypeSignature(fields) {
         .join('\n');
 }
 
+
+function getSortedJsonKeys(json) {
+    const keys = Object.keys(json);
+
+    if (Array.isArray(json))
+        return keys;
+
+    return keys.sort((left, right) => {
+        const leftProperty = resolverNameProperty(left).name;
+        const rightProperty = resolverNameProperty(right).name;
+        return leftProperty.localeCompare(rightProperty);
+    });
+}
+
 function resolveImplementationType(nameType, fields, type = '') {
     const signature = getImplementationTypeSignature(fields);
     const existentNameType = implementationTypeBySignature.get(signature);
@@ -193,7 +207,7 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
 
     let typeRoot = '';
     let typesArray = [];
-    const keys = Object.keys(json)
+    const keys = getSortedJsonKeys(json);
 
 
 


### PR DESCRIPTION
### Motivation
- Make generated V struct fields deterministic and easier to compare side-by-side by alphabetizing object fields according to their final V field names while preserving array element order.

### Description
- Added `getSortedJsonKeys(json)` which returns `Object.keys(json)` but sorts object keys by `resolverNameProperty(key).name` using `localeCompare` and keeps arrays in original order.
- Updated `constructStrucFromJson` to use `getSortedJsonKeys(json)` instead of `Object.keys(json)` so generated struct fields are emitted in alphabetized order. 
- Placed the new helper near `getImplementationTypeSignature` and kept sorting logic localized to key enumeration.

### Testing
- Ran a Node VM smoke test that loads the generator scripts with browser stubs and asserts that root and nested struct fields appear in alphabetical order, and the test passed.