### PR TITLE
Corrige colisão de nomes de structs aninhadas

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ let afterImplementationTypes = [];
 /** @type {Map<string, string>} */
 let implementationTypeBySignature = new Map();
 
+/** @type {Map<string, string>} */
+let implementationSignatureByType = new Map();
+
+/** @type {Set<string>} */
+let reservedImplementationTypeNames = new Set();
+
 const defaultJson = '{\n\t"example_construct_struct": "",\n\t"person": {\n\t\t"name": "André",\n\t\t"age": 26\n\t}\n}';
 const lastJsonLocalStorageKey = 'json2v:last-json';
 
@@ -94,8 +100,7 @@ String.prototype.capitalize = function () {
 
 
 function pushAfterImplementationType(type) {
-    if (afterImplementationTypes.find(it => it.nameType === type.nameType) === undefined)
-        afterImplementationTypes.push(type);
+    afterImplementationTypes.push(type);
 }
 
 function getImplementationTypeSignature(fields) {
@@ -122,21 +127,70 @@ function getSortedJsonKeys(json) {
     });
 }
 
+function getUniqueImplementationTypeName(nameType) {
+    if (!implementationSignatureByType.has(nameType) && !reservedImplementationTypeNames.has(nameType))
+        return nameType;
+
+    let count = 2;
+    let uniqueNameType = `${nameType}${count}`;
+
+    while (implementationSignatureByType.has(uniqueNameType) || reservedImplementationTypeNames.has(uniqueNameType)) {
+        count++;
+        uniqueNameType = `${nameType}${count}`;
+    }
+
+    return uniqueNameType;
+}
+
+
+function getImplementationTypeOrder(nameType) {
+    const nameParts = nameType.match(/^(.*?)(\d+)?$/);
+    return {
+        name: nameParts[1],
+        index: nameParts[2] === undefined ? 1 : Number(nameParts[2])
+    };
+}
+
+function sortImplementationTypes(left, right) {
+    const leftOrder = getImplementationTypeOrder(left.nameType);
+    const rightOrder = getImplementationTypeOrder(right.nameType);
+    const nameCompare = leftOrder.name.localeCompare(rightOrder.name);
+
+    if (nameCompare !== 0)
+        return nameCompare;
+
+    return leftOrder.index - rightOrder.index;
+}
+
+function reserveImplementationTypeName(nameType) {
+    const reservedNameType = getUniqueImplementationTypeName(nameType);
+    reservedImplementationTypeNames.add(reservedNameType);
+    return reservedNameType;
+}
+
 function resolveImplementationType(nameType, fields, type = '') {
     const signature = getImplementationTypeSignature(fields);
     const existentNameType = implementationTypeBySignature.get(signature);
 
-    if (existentNameType !== undefined)
+    if (existentNameType !== undefined) {
+        reservedImplementationTypeNames.delete(nameType);
         return existentNameType;
+    }
 
-    implementationTypeBySignature.set(signature, nameType);
+    const resolvedNameType = reservedImplementationTypeNames.has(nameType)
+        ? nameType
+        : getUniqueImplementationTypeName(nameType);
+
+    reservedImplementationTypeNames.delete(resolvedNameType);
+    implementationTypeBySignature.set(signature, resolvedNameType);
+    implementationSignatureByType.set(resolvedNameType, signature);
     pushAfterImplementationType({
-        nameType: nameType,
+        nameType: resolvedNameType,
         types: [fields],
         type: type
     });
 
-    return nameType;
+    return resolvedNameType;
 }
 
 
@@ -146,19 +200,19 @@ function resolveImplementationType(nameType, fields, type = '') {
 function jsonToStruct(js, type_obj = undefined) {
     afterImplementationTypes = [];
     implementationTypeBySignature = new Map();
+    implementationSignatureByType = new Map();
+    reservedImplementationTypeNames = new Set();
     let code = constructStrucFromJson(js, type_obj).code;
 
     if (code === null)
         return null;
 
-    codeAfeterImplementation = afterImplementationTypes.map(it => {
+    const codeAfeterImplementation = afterImplementationTypes.sort(sortImplementationTypes).map(it => {
         if (it.type == 'sumType')
             return `${canIsPublic()}type ${it.nameType} = ${it.types.map(it => it.view).join(' | ')}`;
         else if (it.types.length == 0)
             return `${canIsPublic()}struct ${it.nameType}{}`;
-        else
-        {
-            debugger
+        else {
             return `${canIsPublic()}struct ${it.nameType} {${canIsPublicForFields(it.types[0])}\n${it.types[0]}}\n`;
         }
     }).join('\n');
@@ -242,10 +296,15 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
 
         } else if (currentTypeIsArray(currentType)) {
             /* Get element by element of array */
+            const nameObj = !Array.isArray(json) ? keys[key] : undefined;
+            const reservedNameType = nameObj !== undefined && !flagStructAnon
+                ? reserveImplementationTypeName(resolverNameType(nameObj))
+                : undefined;
             let contentTree = constructStrucFromJson(json[keys[key]],
                 {
                     ...currentType,
-                    nameObj: !Array.isArray(json) ? keys[key] : undefined
+                    nameObj: nameObj,
+                    reservedNameType: reservedNameType
                 });
 
             if (contentTree === '')
@@ -259,10 +318,15 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
             /**
              * Object or Array of key nested
              */
+            const nameObj = !Array.isArray(json) ? keys[key] : undefined;
+            const reservedNameType = nameObj !== undefined && !flagStructAnon
+                ? reserveImplementationTypeName(resolverNameType(nameObj))
+                : undefined;
             let contentTree = constructStrucFromJson(json[keys[key]],
                 {
                     ...currentType,
-                    nameObj: !Array.isArray(json) ? keys[key] : undefined
+                    nameObj: nameObj,
+                    reservedNameType: reservedNameType
                 });
 
 
@@ -315,7 +379,7 @@ function constructStrucFromJson(js, hiritageObj = undefined) {
                 return 'Undefined';
         })();
 
-        const nameType = resolverNameType(name);
+        const nameType = hiritageObj.reservedNameType ?? resolverNameType(name);
         let resolvedNameType = nameType;
 
         if (!flagStructAnon) {

--- a/types.js
+++ b/types.js
@@ -51,7 +51,7 @@ var RESERVED_WORDS = [
  * @returns {{nameType: string, view: string, base: string}}
  */
 function getType(input) {
-    type = typeof (input);
+    const type = typeof (input);
     if (type === 'number')
         return {
             nameType: Number.isInteger(input) ? 'int' : 'f32',


### PR DESCRIPTION
### Motivation
- Nested objects that share the same JSON key were collapsing into a single helper struct, losing deeper nested types and producing incorrect output.
- The generator needs stable, distinct helper type names so nested keys like `sub` produce `Sub`, `Sub2`, `Sub3`, etc., and still reuse identical-structure types when appropriate.

### Description
- Added bookkeeping for helper type signatures and reserved names with new structures `implementationSignatureByType` and `reservedImplementationTypeNames` and helper functions `getUniqueImplementationTypeName` and `reserveImplementationTypeName` in `index.js`.
- Reserve the child type name before recursing so the closest nested object keeps the base name and deeper objects get numeric suffixes, and pass the reserved name via `hiritageObj.reservedNameType` to `constructStrucFromJson`.
- Adjusted `resolveImplementationType` to return/assign unique or reserved names and always register generated helper structs; sort helper structs with `sortImplementationTypes` for stable output order.
- Fixed a leaking global by making `type` local in `getType` (`types.js`) and simplified `pushAfterImplementationType` to always append.

### Testing
- Ran a Node VM regression script that asserts the nested sample produces `Sub`, `Sub2`, `Sub3` and that helper structs are emitted in the correct order, and the script passed.
- Verified reuse behaviour with another Node VM test where identical object shapes reuse the same struct name and it passed.
- Performed quick syntax checks with `node -c index.js` and `node -c types.js`, both succeeded.