### PR TITLE
Atualiza ações do workflow de deploy do GitHub Pages

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Corrigir erro de execução causado pela dependência obsoleta de `actions/upload-artifact@v3` quando usado indiretamente por `actions/upload-pages-artifact@v1`, garantindo compatibilidade com as versões atuais das actions.

### Description
- Atualiza `.github/workflows/page.yml` trocando `actions/checkout@v3` → `actions/checkout@v4`, `actions/configure-pages@v3` → `actions/configure-pages@v5`, `actions/upload-pages-artifact@v1` → `actions/upload-pages-artifact@v3` e `actions/deploy-pages@v2` → `actions/deploy-pages@v4`.

### Testing
- Testes automatizados realizados: validação do YAML via `ruby -e` que confirmou os valores `uses` esperados (sucesso) e `git diff --check` (sucesso), enquanto a verificação em `python` com `PyYAML` não pôde ser executada porque o pacote `yaml` não está instalado no ambiente (falha).